### PR TITLE
Fix #7: setting conversion fails when the optional audio codecOptions…

### DIFF
--- a/test/audio-parameters.test.js
+++ b/test/audio-parameters.test.js
@@ -4,7 +4,6 @@
  */
 
 const AudioParameters = require('../src/audio-parameters');
-const removeEmpty = require('../src/remove-empty');
 
 describe('AudioParameters()', () => {
   test('Simple AAC conversion', () => {
@@ -33,8 +32,34 @@ describe('AudioParameters()', () => {
       audioSourceName: "Audio Selector 1"
     };
 
-    const res = removeEmpty(AudioParameters(audioParams));
+    const res = AudioParameters(audioParams);
 
     expect(res).toEqual(expected);
+  });
+
+  test('Vorbis conversion', () => {
+    const audioParams = {
+      "_path": [],
+      "bitRate": "160",
+      "channels": "2",
+      "codec": "vorbis",
+      "sampleRate": "44100"
+    };
+
+    const expected = {
+      codecSettings: {
+        codec: "VORBIS",
+        vorbisSettings: {
+          sampleRate: 44100,
+          channels: 2
+        }
+      },
+      audioSourceName: "Audio Selector 1"
+    };
+
+    const res = AudioParameters(audioParams);
+
+    expect(res).toEqual(expected);
+    expect(global.messages[0].message).toMatch(/MediaConvert does not support vorbis bitrate./);
   });
 });


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/migrate-workflow-from-amazon-elastic-trancoder-to-aws-elemental-mediaconvert/issues/7

*Description of changes:*

1. Fix the bug that cause audio conversion to fail when the optional audio codecOptions is undefined.
2. Only convert audio bitrate when it's supported by MediaConvert. If not support emit a warning message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
