### PR TITLE
Mirror Elastic Transcoder video buffer size behavior for MediaConvert HRD Buffer Size.

### DIFF
--- a/src/make-codec-settings.js
+++ b/src/make-codec-settings.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT-0
  */
 
-const { addWarnMessage } = require('./add-message');
+const { addInfoMessage, addWarnMessage } = require('./add-message');
 const { getPar } = require('./get-par');
 const removeEmpty = require('./remove-empty');
 
@@ -240,6 +240,13 @@ function getHrdBufferSize(videoParams) {
   }
 
   if (maxBitrate) {
+    addWarnMessage(
+      [...videoParams._path, 'bufferSize'],
+      `${videoParams.codec} video buffer size is not specified. Using 10 times the value of ` +
+      'maxBitRate (or the max of MediaConvert value) for hrdBufferSize to mimic the behavior of ' +
+      'Elastic Transcoder.'
+    );
+
     const hrdBufferSize = maxBitrate * 10;
     return maxHrdBufferSize ? Math.min(maxHrdBufferSize, hrdBufferSize) : hrdBufferSize;
   }

--- a/src/video-parameters.js
+++ b/src/video-parameters.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT-0
  */
 
-const makeCodecSettings = require('./make-codec-settings');
+const {makeCodecSettings} = require('./make-codec-settings');
 const makeColorCorrector = require('./make-color-corrector');
 const getResolution = require('./get-resolution');
 const SizingPolicy = require('./sizing-policy');

--- a/test/job-input.test.js
+++ b/test/job-input.test.js
@@ -11,6 +11,10 @@ describe('JobInput()', () => {
     global.args = {};
     global.pipeline = {inputBucket: 'inputs'};
     global.messages = [];
+    global.presets = {
+      '1351620000001-200060': require('./fixtures/presets/1351620000001-200060_hls_audio_160k.json'),
+      '1351620000001-200055': require('./fixtures/presets/1351620000001-200055_hls_video_400k.json')
+    };
   });
 
   it('should make fileInput S3 key', () => {

--- a/test/job-input.test.js
+++ b/test/job-input.test.js
@@ -11,10 +11,6 @@ describe('JobInput()', () => {
     global.args = {};
     global.pipeline = {inputBucket: 'inputs'};
     global.messages = [];
-    global.presets = {
-      '1351620000001-200060': require('./fixtures/presets/1351620000001-200060_hls_audio_160k.json'),
-      '1351620000001-200055': require('./fixtures/presets/1351620000001-200055_hls_video_400k.json')
-    };
   });
 
   it('should make fileInput S3 key', () => {

--- a/test/make-codec-settings.test.js
+++ b/test/make-codec-settings.test.js
@@ -4,7 +4,206 @@
  */
 
 const addPath = require("../src/add-path");
-const makeCodecSettings = require("../src/make-codec-settings");
+const {getHrdBufferSize, makeCodecSettings} = require("../src/make-codec-settings");
+
+describe('getHrdBufferSize()', () => {
+  beforeEach(() => {
+    global.messages = [];
+  });
+
+  it('should return undefined when buffer size and max bitrate are undefined', () => {
+    const videoParams = addPath({
+      codec: 'H.264',
+      codecOptions: {
+        profile: 'baseline'
+      }
+    }, []);
+
+    expect(getHrdBufferSize(videoParams)).toBeUndefined()
+  });
+
+  it('should return original buffer size when it is defined', () => {
+    const videoParams = addPath({
+      codec: 'H.264',
+      codecOptions: {
+        profile: 'baseline',
+        bufferSize: '10'
+      }
+    }, []);
+
+    expect(getHrdBufferSize(videoParams)).toBe(10000)
+  });
+
+  it('should cap buffer size', () => {
+    const videoParams = addPath({
+      codec: 'H.264',
+      codecOptions: {
+        profile: 'baseline',
+        level: '1',
+        bufferSize: '211'
+      }
+    }, []);
+
+    expect(getHrdBufferSize(videoParams)).toBe(210000);
+    expect(global.messages.find(
+      message => message.message.includes('video buffer size is larger than MediaConvert maximum ')
+    )).toBeDefined();
+  });
+
+  it('should return 10x max bitrate', () => {
+    const videoParams = addPath({
+      codec: 'H.264',
+      codecOptions: {
+        profile: 'baseline',
+        level: '1',
+        maxBitRate: '10'
+      }
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBe(100000);
+  });
+
+  it('should cap 10x max bitrate', () => {
+    const videoParams = addPath({
+      codec: 'H.264',
+      codecOptions: {
+        profile: 'baseline',
+        level: '1',
+        maxBitRate: '1000'
+      }
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBe(210000);
+  });
+
+  it('should return undefined for gif', () => {
+    const videoParams = addPath({
+      codec: 'gif'
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBeUndefined();
+  });
+
+  it('should return original buffer size when it is defined for VP8', () => {
+    const videoParams = addPath({
+      codec: 'vp8',
+      codecOptions: {
+        profile: '0',
+        bufferSize: '10'
+      }
+    }, []);
+
+    expect(getHrdBufferSize(videoParams)).toBe(10000)
+  });
+
+  it('should cap buffer size for VP8', () => {
+    const videoParams = addPath({
+      codec: 'vp8',
+      codecOptions: {
+        profile: '0',
+        bufferSize: '50000'
+      }
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBe(47185920);
+  });
+
+  it('should cap max bitrate for VP8', () => {
+    const videoParams = addPath({
+      codec: 'vp8',
+      codecOptions: {
+        profile: '0',
+        maxBitRate: '50000'
+      }
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBe(47185920);
+  });
+
+  it('should return original buffer size when it is defined for VP9', () => {
+    const videoParams = addPath({
+      codec: 'vp9',
+      codecOptions: {
+        profile: '0',
+        bufferSize: '10'
+      }
+    }, []);
+
+    expect(getHrdBufferSize(videoParams)).toBe(10000)
+  });
+
+  it('should cap buffer size for VP9', () => {
+    const videoParams = addPath({
+      codec: 'vp9',
+      codecOptions: {
+        profile: '0',
+        bufferSize: '50000'
+      }
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBe(47185920);
+  });
+
+  it('should cap max bitrate for VP9', () => {
+    const videoParams = addPath({
+      codec: 'vp9',
+      codecOptions: {
+        profile: '0',
+        maxBitRate: '50000'
+      }
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBe(47185920);
+  });
+
+  it('should return original buffer size when it is defined for MPEG2', () => {
+    const videoParams = addPath({
+      codec: 'mpeg2',
+      codecOptions: {
+        bufferSize: '10'
+      }
+    }, []);
+
+    expect(getHrdBufferSize(videoParams)).toBe(10000)
+  });
+
+  it('should cap buffer size for MPEG2 yuv420p', () => {
+    const videoParams = addPath({
+      codec: 'mpeg2',
+      codecOptions: {
+        chromaSubsampling: 'yuv420p',
+        bufferSize: '10000'
+      }
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBe(9781248);
+  });
+
+  it('should cap max bitrate for MPEG2 yuv420p', () => {
+    const videoParams = addPath({
+      codec: 'mpeg2',
+      codecOptions: {
+        chromaSubsampling: 'yuv420p',
+        maxBitRate: '10000'
+      }
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBe(9781248);
+  });
+
+  it('should cap buffer size for MPEG2 yuv422p', () => {
+    const videoParams = addPath({
+      codec: 'mpeg2',
+      codecOptions: {
+        chromaSubsampling: 'yuv422p',
+        bufferSize: '50000'
+      }
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBe(47185920);
+  });
+
+  it('should cap max bitrate for MPEG2 yuv422p', () => {
+    const videoParams = addPath({
+      codec: 'mpeg2',
+      codecOptions: {
+        chromaSubsampling: 'yuv422p',
+        maxBitRate: '50000'
+      }
+    }, []);
+    expect(getHrdBufferSize(videoParams)).toBe(47185920);
+  });
+});
 
 describe('makeCodecSettings()', () => {
   beforeEach(() => {

--- a/test/make-codec-settings.test.js
+++ b/test/make-codec-settings.test.js
@@ -60,6 +60,9 @@ describe('getHrdBufferSize()', () => {
       }
     }, []);
     expect(getHrdBufferSize(videoParams)).toBe(100000);
+    expect(global.messages.find(
+      message => message.message.includes('Using 10 times the value of maxBitRate')
+    )).toBeDefined();
   });
 
   it('should cap 10x max bitrate', () => {
@@ -72,6 +75,9 @@ describe('getHrdBufferSize()', () => {
       }
     }, []);
     expect(getHrdBufferSize(videoParams)).toBe(210000);
+    expect(global.messages.find(
+      message => message.message.includes('Using 10 times the value of maxBitRate')
+    )).toBeDefined();
   });
 
   it('should return undefined for gif', () => {
@@ -113,6 +119,9 @@ describe('getHrdBufferSize()', () => {
       }
     }, []);
     expect(getHrdBufferSize(videoParams)).toBe(47185920);
+    expect(global.messages.find(
+      message => message.message.includes('Using 10 times the value of maxBitRate')
+    )).toBeDefined();
   });
 
   it('should return original buffer size when it is defined for VP9', () => {
@@ -147,6 +156,9 @@ describe('getHrdBufferSize()', () => {
       }
     }, []);
     expect(getHrdBufferSize(videoParams)).toBe(47185920);
+    expect(global.messages.find(
+      message => message.message.includes('Using 10 times the value of maxBitRate')
+    )).toBeDefined();
   });
 
   it('should return original buffer size when it is defined for MPEG2', () => {
@@ -180,6 +192,9 @@ describe('getHrdBufferSize()', () => {
       }
     }, []);
     expect(getHrdBufferSize(videoParams)).toBe(9781248);
+    expect(global.messages.find(
+      message => message.message.includes('Using 10 times the value of maxBitRate')
+    )).toBeDefined();
   });
 
   it('should cap buffer size for MPEG2 yuv422p', () => {
@@ -202,6 +217,9 @@ describe('getHrdBufferSize()', () => {
       }
     }, []);
     expect(getHrdBufferSize(videoParams)).toBe(47185920);
+    expect(global.messages.find(
+      message => message.message.includes('Using 10 times the value of maxBitRate')
+    )).toBeDefined();
   });
 });
 


### PR DESCRIPTION
Mirror Elastic Transcoder video buffer size behavior for MediaConvert HRD Buffer Size.

If Elastic Transcoder buffer size is defined, use that for MediaConvert HRD Buffer size.

If Elastic Transcoder buffer size is not defined, but max bitrate is defined, then use 10x of max bitrate (capped to the max HRD buffer size of MediaConvert).

If neither buffer size or max bitrate is defined, HRD Buffer size is not set.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
